### PR TITLE
Support adding multiple images

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 </head>
 <body>
 <h1>Motion Picture Film Maker</h1>
-<p>画像を選択してフィルム風のスライドショーを作成し、GIFとしてダウンロードできます。</p>
+<p>画像を選択・追加してフィルム風のスライドショーを作成し、GIFとしてダウンロードできます。</p>
 <input type="file" id="image-upload" accept="image/*" multiple>
 <button id="generate-gif" disabled>GIF生成</button>
 <div class="filmstrip" id="filmstrip"></div>
@@ -50,8 +50,6 @@ const generateBtn = document.getElementById('generate-gif');
 let imageUrls = [];
 
 imageInput.addEventListener('change', (e) => {
-    filmstrip.innerHTML = '';
-    imageUrls = [];
     Array.from(e.target.files).forEach(file => {
         const url = URL.createObjectURL(file);
         imageUrls.push(url);
@@ -60,6 +58,7 @@ imageInput.addEventListener('change', (e) => {
         filmstrip.appendChild(img);
     });
     generateBtn.disabled = imageUrls.length === 0;
+    imageInput.value = '';
 });
 
 generateBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- allow incremental image selection when creating GIF slideshows
- update instructions to mention that multiple images can be added

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68402000d3f883229f76772f4603262e