### PR TITLE
Enable simple image uploading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+uploads/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 uploads/
+gifs/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>画像アップロード</title>
+</head>
+<body>
+<h1>画像アップロード</h1>
+<form id="upload-form">
+  <input type="file" id="image" name="image" accept="image/*" required>
+  <button type="submit">アップロード</button>
+</form>
+<div id="result"></div>
+<script>
+document.getElementById('upload-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const result = document.getElementById('result');
+  const formData = new FormData();
+  const fileInput = document.getElementById('image');
+  if (fileInput.files.length === 0) {
+    result.textContent = 'ファイルを選択してください。';
+    return;
+  }
+  formData.append('image', fileInput.files[0]);
+  try {
+    const res = await fetch('/upload', {
+      method: 'POST',
+      body: formData
+    });
+    if (res.ok) {
+      const data = await res.json();
+      result.textContent = 'アップロード成功: ' + data.file;
+    } else {
+      result.textContent = 'アップロード失敗';
+    }
+  } catch (err) {
+    result.textContent = 'エラーが発生しました';
+  }
+});
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,13 @@
     background: #000;
   }
 
+  #result {
+    display: flex;
+    overflow-x: auto;
+    gap: 10px;
+    padding-top: 10px;
+  }
+
   .film-strip img {
     display: block;
     max-width: 100%;
@@ -39,7 +46,7 @@
 <body>
 <h1>画像アップロード</h1>
 <form id="upload-form">
-  <input type="file" id="image" name="image" accept="image/*" required>
+  <input type="file" id="images" name="images" accept="image/*" multiple required>
   <button type="submit">アップロード</button>
 </form>
 <div id="result"></div>
@@ -48,12 +55,14 @@ document.getElementById('upload-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const result = document.getElementById('result');
   const formData = new FormData();
-  const fileInput = document.getElementById('image');
+  const fileInput = document.getElementById('images');
   if (fileInput.files.length === 0) {
     result.textContent = 'ファイルを選択してください。';
     return;
   }
-  formData.append('image', fileInput.files[0]);
+  for (const file of fileInput.files) {
+    formData.append('images', file);
+  }
   try {
     const res = await fetch('/upload', {
       method: 'POST',
@@ -61,8 +70,13 @@ document.getElementById('upload-form').addEventListener('submit', async (e) => {
     });
     if (res.ok) {
       const data = await res.json();
-      result.innerHTML =
-        `<div class="film-strip"><div class="perforation top"></div><img src="${data.file}" alt="uploaded"><div class="perforation bottom"></div></div>`;
+      result.innerHTML = '';
+      data.files.forEach(file => {
+        const div = document.createElement('div');
+        div.className = 'film-strip';
+        div.innerHTML = `\n          <div class="perforation top"></div>\n          <img src="${file}" alt="uploaded">\n          <div class="perforation bottom"></div>\n        `;
+        result.appendChild(div);
+      });
     } else {
       result.textContent = 'アップロード失敗';
     }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,38 @@
 <head>
 <meta charset="UTF-8">
 <title>画像アップロード</title>
+<style>
+  .film-strip {
+    position: relative;
+    display: inline-block;
+    padding: 20px 0;
+    background: #000;
+  }
+
+  .film-strip img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+
+  .perforation {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 20px;
+    background-color: #000;
+    background-image: repeating-linear-gradient(
+      to right,
+      #fff,
+      #fff 10px,
+      #000 10px,
+      #000 20px
+    );
+  }
+
+  .perforation.top { top: 0; }
+  .perforation.bottom { bottom: 0; }
+</style>
 </head>
 <body>
 <h1>画像アップロード</h1>
@@ -29,7 +61,8 @@ document.getElementById('upload-form').addEventListener('submit', async (e) => {
     });
     if (res.ok) {
       const data = await res.json();
-      result.textContent = 'アップロード成功: ' + data.file;
+      result.innerHTML =
+        `<div class="film-strip"><div class="perforation top"></div><img src="${data.file}" alt="uploaded"><div class="perforation bottom"></div></div>`;
     } else {
       result.textContent = 'アップロード失敗';
     }

--- a/index.html
+++ b/index.html
@@ -49,8 +49,10 @@
   <input type="file" id="images" name="images" accept="image/*" multiple required>
   <button type="submit">アップロード</button>
 </form>
+<button id="download-gif">GIFをダウンロード</button>
 <div id="result"></div>
 <script>
+let uploadedFiles = [];
 document.getElementById('upload-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const result = document.getElementById('result');
@@ -70,6 +72,7 @@ document.getElementById('upload-form').addEventListener('submit', async (e) => {
     });
     if (res.ok) {
       const data = await res.json();
+      uploadedFiles = data.files;
       result.innerHTML = '';
       data.files.forEach(file => {
         const div = document.createElement('div');
@@ -82,6 +85,26 @@ document.getElementById('upload-form').addEventListener('submit', async (e) => {
     }
   } catch (err) {
     result.textContent = 'エラーが発生しました';
+  }
+});
+
+document.getElementById('download-gif').addEventListener('click', async () => {
+  if (uploadedFiles.length === 0) return;
+  const res = await fetch('/gif', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ files: uploadedFiles })
+  });
+  if (res.ok) {
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'film.gif';
+    a.click();
+    URL.revokeObjectURL(url);
   }
 });
 </script>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "multer": "^1.4.5"
+    "multer": "^1.4.5",
+    "gifencoder": "^2.0.1",
+    "canvas": "^2.11.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "motion-picture-film-maker",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -24,9 +24,9 @@ const upload = multer({ storage });
 
 app.use(express.static(__dirname));
 
-app.post('/upload', upload.single('image'), (req, res) => {
-  const filePath = path.join('uploads', req.file.filename);
-  res.json({ message: 'Upload successful', file: filePath });
+app.post('/upload', upload.array('images'), (req, res) => {
+  const files = req.files.map(f => path.join('uploads', f.filename));
+  res.json({ message: 'Upload successful', files });
 });
 
 app.listen(PORT, () => {

--- a/server.js
+++ b/server.js
@@ -25,7 +25,8 @@ const upload = multer({ storage });
 app.use(express.static(__dirname));
 
 app.post('/upload', upload.single('image'), (req, res) => {
-  res.json({ message: 'Upload successful', file: req.file.filename });
+  const filePath = path.join('uploads', req.file.filename);
+  res.json({ message: 'Upload successful', file: filePath });
 });
 
 app.listen(PORT, () => {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+const PORT = 3000;
+
+const uploadDir = path.join(__dirname, 'uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir);
+}
+
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    cb(null, uploadDir);
+  },
+  filename: function (req, file, cb) {
+    cb(null, Date.now() + '-' + file.originalname);
+  }
+});
+
+const upload = multer({ storage });
+
+app.use(express.static(__dirname));
+
+app.post('/upload', upload.single('image'), (req, res) => {
+  res.json({ message: 'Upload successful', file: req.file.filename });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const GIFEncoder = require('gifencoder');
+const { createCanvas, loadImage } = require('canvas');
 
 const app = express();
 const PORT = 3000;
@@ -9,6 +11,10 @@ const PORT = 3000;
 const uploadDir = path.join(__dirname, 'uploads');
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir);
+}
+const gifDir = path.join(__dirname, 'gifs');
+if (!fs.existsSync(gifDir)) {
+  fs.mkdirSync(gifDir);
 }
 
 const storage = multer.diskStorage({
@@ -27,6 +33,49 @@ app.use(express.static(__dirname));
 app.post('/upload', upload.array('images'), (req, res) => {
   const files = req.files.map(f => path.join('uploads', f.filename));
   res.json({ message: 'Upload successful', files });
+});
+
+app.post('/gif', express.json(), async (req, res) => {
+  const files = req.body.files || [];
+  if (!Array.isArray(files) || files.length === 0) {
+    return res.status(400).json({ error: 'No files provided' });
+  }
+
+  const width = 1280;
+  const height = 720;
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+  const encoder = new GIFEncoder(width, height);
+  const gifPath = path.join(gifDir, Date.now() + '.gif');
+  const stream = fs.createWriteStream(gifPath);
+  encoder.createReadStream().pipe(stream);
+  encoder.start();
+  encoder.setRepeat(0);
+  encoder.setDelay(500);
+  encoder.setQuality(10);
+
+  for (const file of files) {
+    try {
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, width, height);
+      const img = await loadImage(path.join(__dirname, file));
+      const ratio = Math.min(width / img.width, height / img.height);
+      const iw = img.width * ratio;
+      const ih = img.height * ratio;
+      const ix = (width - iw) / 2;
+      const iy = (height - ih) / 2;
+      ctx.drawImage(img, ix, iy, iw, ih);
+      encoder.addFrame(ctx);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+  encoder.finish();
+  stream.on('finish', () => {
+    res.download(gifPath, 'film.gif', err => {
+      fs.unlink(gifPath, () => {});
+    });
+  });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add Node/Express server with a POST `/upload` endpoint
- add HTML form to upload images
- add package.json and .gitignore

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68404982c6dc8322a4a3e9dd6e942540