### PR TITLE
Implement client-side preview and CLI GIF creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,68 +44,31 @@
 </style>
 </head>
 <body>
-<h1>画像アップロード</h1>
+<h1>画像プレビュー</h1>
 <form id="upload-form">
   <input type="file" id="images" name="images" accept="image/*" multiple required>
-  <button type="submit">アップロード</button>
+  <button type="submit">表示</button>
 </form>
-<button id="download-gif">GIFをダウンロード</button>
+<p>GIF作成は <code>node makegif.js 出力.gif 画像1 画像2 ...</code> を実行してください。</p>
 <div id="result"></div>
 <script>
-let uploadedFiles = [];
-document.getElementById('upload-form').addEventListener('submit', async (e) => {
+const fileInput = document.getElementById('images');
+const result = document.getElementById('result');
+
+document.getElementById('upload-form').addEventListener('submit', (e) => {
   e.preventDefault();
-  const result = document.getElementById('result');
-  const formData = new FormData();
-  const fileInput = document.getElementById('images');
+  result.innerHTML = '';
   if (fileInput.files.length === 0) {
     result.textContent = 'ファイルを選択してください。';
     return;
   }
-  for (const file of fileInput.files) {
-    formData.append('images', file);
-  }
-  try {
-    const res = await fetch('/upload', {
-      method: 'POST',
-      body: formData
-    });
-    if (res.ok) {
-      const data = await res.json();
-      uploadedFiles = data.files;
-      result.innerHTML = '';
-      data.files.forEach(file => {
-        const div = document.createElement('div');
-        div.className = 'film-strip';
-        div.innerHTML = `\n          <div class="perforation top"></div>\n          <img src="${file}" alt="uploaded">\n          <div class="perforation bottom"></div>\n        `;
-        result.appendChild(div);
-      });
-    } else {
-      result.textContent = 'アップロード失敗';
-    }
-  } catch (err) {
-    result.textContent = 'エラーが発生しました';
-  }
-});
-
-document.getElementById('download-gif').addEventListener('click', async () => {
-  if (uploadedFiles.length === 0) return;
-  const res = await fetch('/gif', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ files: uploadedFiles })
+  Array.from(fileInput.files).forEach(file => {
+    const url = URL.createObjectURL(file);
+    const div = document.createElement('div');
+    div.className = 'film-strip';
+    div.innerHTML = `\n      <div class="perforation top"></div>\n      <img src="${url}" alt="uploaded">\n      <div class="perforation bottom"></div>\n    `;
+    result.appendChild(div);
   });
-  if (res.ok) {
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'film.gif';
-    a.click();
-    URL.revokeObjectURL(url);
-  }
 });
 </script>
 </body>

--- a/makegif.js
+++ b/makegif.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const { createCanvas, loadImage } = require('canvas');
+const GIFEncoder = require('gifencoder');
+
+async function createGif(output, images, options = {}) {
+  const width = options.width || 1280;
+  const height = options.height || 720;
+  const delay = options.delay || 500;
+
+  const encoder = new GIFEncoder(width, height);
+  const writeStream = fs.createWriteStream(output);
+  encoder.createReadStream().pipe(writeStream);
+
+  encoder.start();
+  encoder.setRepeat(0);
+  encoder.setDelay(delay);
+  encoder.setQuality(10);
+
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+
+  for (const file of images) {
+    try {
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, width, height);
+      const img = await loadImage(file);
+      const ratio = Math.min(width / img.width, height / img.height);
+      const iw = img.width * ratio;
+      const ih = img.height * ratio;
+      const ix = (width - iw) / 2;
+      const iy = (height - ih) / 2;
+      ctx.drawImage(img, ix, iy, iw, ih);
+      encoder.addFrame(ctx);
+    } catch (err) {
+      console.error(`Failed to add ${file}:`, err);
+    }
+  }
+  encoder.finish();
+  return new Promise(resolve => writeStream.on('finish', resolve));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.log('Usage: node makegif.js output.gif image1 image2 ...');
+    process.exit(1);
+  }
+  const output = args[0];
+  const images = args.slice(1);
+  await createGif(output, images);
+  console.log(`GIF saved to ${output}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "gif": "node makegif.js"
   },
   "dependencies": {
     "express": "^4.18.2",


### PR DESCRIPTION
## Summary
- remove express upload logic from the webpage
- guide users to use `makegif.js` script
- add `makegif.js` node script for GIF creation
- expose `npm run gif` script for convenience

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840c716c91883228c98dee2288f1079