### PR TITLE
Add Node.js CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,27 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install canvas dependencies
+        run: sudo apt-get update && sudo apt-get install -y \ 
+          libcairo2-dev libjpeg-dev libpango1.0-dev \ 
+          libgif-dev librsvg2-dev
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "gif": "node makegif.js"
+    "gif": "node makegif.js",
+    "test": "node test/test.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,23 @@
+const { createCanvas } = require('canvas');
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+function createImage(path, color) {
+  const canvas = createCanvas(50, 50);
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, 50, 50);
+  fs.writeFileSync(path, canvas.toBuffer('image/png'));
+}
+
+function main() {
+  createImage('img1.png', 'red');
+  createImage('img2.png', 'blue');
+  execSync('node makegif.js test.gif img1.png img2.png', { stdio: 'inherit' });
+  if (!fs.existsSync('test.gif')) {
+    throw new Error('GIF not generated');
+  }
+  console.log('GIF generated successfully');
+}
+
+main();


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Node CI
- include simple test that runs `makegif.js`
- wire up `npm test` script

## Testing
- `npm install` *(fails: 403 Forbidden for canvas)*
- `npm test` *(fails: Cannot find module 'canvas')*

------
https://chatgpt.com/codex/tasks/task_e_6840cceeea548322b5dfc5a5d3cac59e